### PR TITLE
Beef up sample app, and update readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ try app.run()
 
 ## Take it for a spin
 
-We've included a sample Vapor application in this repo to show off its usage. Simply perform the following:
+We've included a sample Vapor application in this repo to show off its usage. To run the app immediately, simply do:
+
+* `swift run HtmlVaporSupportExample`
+* Open your browser to `http://localhost:8080`
+
+The HTML for that page is constructed and rendered with swift-html!
+
+If you want to run the app in Xcode so that you can play around with the HTML, try this:
 
 * `git clone https://github.com/pointfreeco/swift-html-vapor`
 * `cd swift-html-vapor`
@@ -38,8 +45,6 @@ We've included a sample Vapor application in this repo to show off its usage. Si
 * Select the `HtmlVaporSupportExample` target
 * Build and run `cmd+R`
 * Open your browser to `http://localhost:8080`
-
-The HTML for that page is constructed and rendered with swift-html!
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The most popular choice for rendering HTML in a Vapor web app is to use the Leaf templating language, but it exposes your application to **runtime errors** and **invalid HTML**. Our plugin prevents these runtime issues at compile-time by embedding HTML directly into Swift’s powerful type system. It uses the [swift-html](https://github.com/pointfreeco/swift-html) DSL for constructing HTML documents using plain Swift data structures.
 
-## Example
+## Usage
 
 To use the plugin all you have to do is return a `Node` value from your router callback:
 
@@ -27,6 +27,19 @@ router.get("/") { _ in
 
 try app.run()
 ```
+
+## Take it for a spin
+
+We've included a sample Vapor application in this repo to show off its usage. Simply perform the following:
+
+* `git clone https://github.com/pointfreeco/swift-html-vapor`
+* `cd swift-html-vapor`
+* `make xcodeproj`
+* Select the `HtmlVaporSupportExample` target
+* Build and run `cmd+R`
+* Open your browser to `http://localhost:8080`
+
+The HTML for that page is constructed and rendered with swift-html!
 
 ## Installation
 

--- a/Sources/HtmlVaporSupportExample/main.swift
+++ b/Sources/HtmlVaporSupportExample/main.swift
@@ -4,10 +4,7 @@ import Vapor
 let app = try Application()
 let router = try app.make(Router.self)
 
-router.get("/") { _ in
-  html([
-    head([
-      style("""
+let stylesheet: StaticString = """
 body {
   padding: 0.5rem;
   line-height: 1.35;
@@ -21,17 +18,79 @@ blockquote {
   margin-left: 1rem;
   padding-left: 0.5rem;
 }
-""")
-      ]),
+
+pre {
+  background-color: #f3f3f3;
+  padding: 0.5rem;
+  overflow-x: scroll;
+}
+
+code {
+  background-color: #f3f3f3;
+  padding: 0.25rem;
+}
+
+li:not(:last-child) {
+    margin-bottom: 0.25rem;
+}
+
+h2 {
+  margin-top: 2rem;
+  margin-bottom: 0;
+}
+"""
+
+router.get("/") { _ in
+  html([
+    head([style(stylesheet)]),
+
     body([
-      h1(["swift-html"]),
-      blockquote(["""
-A Swift DSL for constructing and rendering HTML documents.
+      h1(["swift-html-vapor"]),
+      blockquote([
+        "A Vapor plugin for type-safe, transformable HTML views using ",
+        a([href("https://github.com/pointfreeco/swift-html")], ["swift-html"])
+        ]),
+
+      h2(["Motivation"]),
+      p(["""
+The most popular choice for rendering HTML in a Vapor web app is to use the Leaf templating language,
+but it exposes your application to runtime errors and invalid HTML. Our plugin prevents these
+runtime issues at compile-time by embedding HTML directly into Swift’s powerful type system. It uses the
+swift-html DSL for constructing HTML documents using plain Swift data structures.
 """
         ]),
+
+      h2(["Usage"]),
       p(["""
-This library provides a deep embedding of an HTML tree structure into the Swift programming language.
+To use the plugin all you have to do is return a `Node` value from your router callback:
+"""]),
+      pre(["""
+import HtmlVaporSupport
+import Vapor
+
+let app = try Application()
+let router = try app.make(Router.self)
+
+router.get("/") { _ in
+  h1(["Hello, type-safe HTML on Vapor!"])
+}
+
+try app.run()
 """
+        ]),
+
+      h2(["Take it for a spin"]),
+      p(["""
+We've included a sample Vapor application in this repo to show off its usage. Simply perform
+the following:
+"""]),
+      ul([
+        li([code(["git clone https://github.com/pointfreeco/swift-html-vapor"])]),
+        li([code(["cd swift-html-vapor"])]),
+        li([code(["make xcodeproj"])]),
+        li(["Select the ", code(["HtmlVaporSupportExample"]), " target"]),
+        li(["Build and run ", code(["cmd+R"])]),
+        li(["Open your browser to ", code(["http://localhost:8080`"])])
         ])
       ])
     ])

--- a/Sources/HtmlVaporSupportExample/main.swift
+++ b/Sources/HtmlVaporSupportExample/main.swift
@@ -81,8 +81,18 @@ try app.run()
 
       h2(["Take it for a spin"]),
       p(["""
-We've included a sample Vapor application in this repo to show off its usage. Simply perform
-the following:
+We've included a sample Vapor application in this repo to show off its usage. To run the app
+immediately, simply do:
+"""]),
+      ul([
+        li([code(["swift run HtmlVaporSupportExample"])]),
+        li(["Open your browser to ", code(["http://localhost:8080"])])
+        ]),
+      p(["""
+The HTML for that page is constructed and rendered with swift-html!
+"""]),
+      p(["""
+If you want to run the app in Xcode so that you can play around with the HTML, try this:
 """]),
       ul([
         li([code(["git clone https://github.com/pointfreeco/swift-html-vapor"])]),


### PR DESCRIPTION
We can better call out that we include a sample app to show the plugin usage. I also recreated some of the README directly in the sample app.