### PR TITLE
Make a better vapor example.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "AEXML",
-        "repositoryURL": "https://github.com/tadija/AEXML",
-        "state": {
-          "branch": null,
-          "revision": "54bb8ea6fb693dd3f92a89e5fcc19e199fdeedd0",
-          "version": "4.3.3"
-        }
-      },
-      {
         "package": "Console",
         "repositoryURL": "https://github.com/vapor/console.git",
         "state": {
@@ -56,39 +47,12 @@
         }
       },
       {
-        "package": "JSONUtilities",
-        "repositoryURL": "https://github.com/yonaskolb/JSONUtilities.git",
-        "state": {
-          "branch": null,
-          "revision": "db238f4858ac2ac3fff228b5b71ce90488a6a9b3",
-          "version": "4.1.0"
-        }
-      },
-      {
         "package": "Multipart",
         "repositoryURL": "https://github.com/vapor/multipart.git",
         "state": {
           "branch": null,
           "revision": "bd7736c5f28e48ed8b683dcc9df3dcd346064c2b",
           "version": "3.0.3"
-        }
-      },
-      {
-        "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit.git",
-        "state": {
-          "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
-        }
-      },
-      {
-        "package": "Rainbow",
-        "repositoryURL": "https://github.com/onevcat/Rainbow.git",
-        "state": {
-          "branch": null,
-          "revision": "797a68d0a642609424b08f11eb56974a54d5f6e2",
-          "version": "3.1.4"
         }
       },
       {
@@ -107,15 +71,6 @@
           "branch": null,
           "revision": "4907311d7d7f609365982fa302b8b17ffdeb46da",
           "version": "1.0.1"
-        }
-      },
-      {
-        "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
-        "state": {
-          "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
         }
       },
       {
@@ -168,26 +123,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
         "state": {
           "branch": null,
-          "revision": "1fb2e65cf62d2f983b3cab2871cbb218ea9ee9b7",
-          "version": "1.3.0"
-        }
-      },
-      {
-        "package": "SwiftCLI",
-        "repositoryURL": "https://github.com/jakeheis/SwiftCLI.git",
-        "state": {
-          "branch": null,
-          "revision": "5318c37d3cacc8780f50b87a8840a6774320ebdf",
-          "version": "5.2.2"
-        }
-      },
-      {
-        "package": "SwiftShell",
-        "repositoryURL": "https://github.com/kareman/SwiftShell",
-        "state": {
-          "branch": null,
-          "revision": "beebe43c986d89ea5359ac3adcb42dac94e5e08a",
-          "version": "4.1.2"
+          "revision": "e25caba146280f7c5cb098202f6d04a9a7f8c760",
+          "version": "1.4.0"
         }
       },
       {
@@ -233,33 +170,6 @@
           "branch": null,
           "revision": "21eb4773e25a8ff96fe347a31fe106900a69fa6a",
           "version": "1.1.1"
-        }
-      },
-      {
-        "package": "XcodeGen",
-        "repositoryURL": "https://github.com/yonaskolb/XcodeGen.git",
-        "state": {
-          "branch": null,
-          "revision": "95bc051d268f6b8b924ae9c84e40566efe90cb80",
-          "version": "2.3.0"
-        }
-      },
-      {
-        "package": "xcodeproj",
-        "repositoryURL": "https://github.com/tuist/xcodeproj.git",
-        "state": {
-          "branch": null,
-          "revision": "8e15cc74149ee946b7ae125685177915b4ff7317",
-          "version": "6.4.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "26ab35f50ea891e8edefcc9d975db2f6b67e1d68",
-          "version": "1.0.1"
         }
       }
     ]

--- a/Sources/HtmlVaporSupportExample/AdvancedUsage.swift
+++ b/Sources/HtmlVaporSupportExample/AdvancedUsage.swift
@@ -1,0 +1,78 @@
+import Html
+
+let advancedUsage: Node = [
+  .h2("Advanced Usage"),
+  .p("""
+Typically you will not want to reconstruct a full HTML document to be rendered for each of your routes. Instead you can build up lots of smaller HTML fragments and piece them together to make a larger document. For example, a persistent header and footer for your site could be broken out into individual nodes:
+"""),
+  .pre(#"""
+// A node that represents the header to use on each page.
+let header: Node = [
+  .header(
+    .h1("Point-Free"),
+    .blockquote("A video series on the Swift programming language and functional programming."),
+    .ul(attributes: [], [
+      .li(.a(attributes: [.href("/")], "Home")),
+      .li(.a(attributes: [.href("/about")], "About")),
+      .li(.a(attributes: [.href("/contact-us")], "Contact Us")),
+      ]
+    )
+  )
+]
+
+// A node that represents the footer to use on each page.
+let footer: Node = [
+  .hr,
+  .footer("© 2019 Point-Free, Inc.")
+]
+"""#),
+  .p("""
+Then, to assemble the parts in a consistent manner we can simply create a function that takes a node as input, which represents the main, central content of your page, and it will return a new node, which is the fully constructed HTML page:
+"""),
+  .pre(#"""
+func layout(content: Node) -> Node {
+  return [
+    .doctype,
+    .html(
+      .head(
+        // Load any external style sheets you need access to:
+        .link(attributes: [
+          .rel(.stylesheet),
+          .href("https://stackpath.bootstrapcdn.com/bootswatch/4.3.1/cerulean/bootstrap.min.css")
+          ])
+      ),
+      .body(
+        header,
+        .main(content),
+        footer,
+        // Load external scripts at the bottom of the document.
+        .script(attributes: [.src("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js")])
+      )
+    )
+  ]
+}
+"""#),
+  .p("""
+Now, in your router you can wrap the content that is specific to that page in your layout by just invoking the \(.code("layout(content:)")) function:
+"""),
+  .pre(#"""
+import HtmlVaporSupport
+import Vapor
+
+let app = try Application()
+let router = try app.make(Router.self)
+
+router.get("/contact-us") { _ in
+  layout(content: [
+    .h1("Contact us"),
+    .p("Feel free to reach out to us with any questions at support@pointfree.co")
+  ])
+}
+
+try app.run()
+"""#
+  ),
+  .p("""
+Now a full HTML page will be rendered, including a \(.code("head")) tag with stylesheets, a header with navigation links, the main content in the middle, and a footer with a copyright notice. The best part is that because everything is just simple Swift data we are free to arrange and compose this data in anyway we want. In particular, we are allowed to keep all of our helper nodes in the same file if we want, or we can break them out into multiple files if that works better for us. Compare that to templates where you are forced to always put views in a new file, no matter how tiny and insignificant it is.
+"""),
+]

--- a/Sources/HtmlVaporSupportExample/Home.swift
+++ b/Sources/HtmlVaporSupportExample/Home.swift
@@ -1,0 +1,11 @@
+import Html
+
+let home: Node = [
+  .p("""
+The most popular choice for rendering HTML in a Vapor web app is to use the Leaf templating language,
+but it exposes your application to runtime errors and invalid HTML. Our plugin prevents these
+runtime issues at compile-time by embedding HTML directly into Swift’s powerful type system. It uses the
+swift-html DSL for constructing HTML documents using plain Swift data structures.
+"""
+  )
+]

--- a/Sources/HtmlVaporSupportExample/Installation.swift
+++ b/Sources/HtmlVaporSupportExample/Installation.swift
@@ -1,4 +1,5 @@
 import Html
+
 let installation: Node = [
   .h2("Take it for a spin"),
   .p("""

--- a/Sources/HtmlVaporSupportExample/Installation.swift
+++ b/Sources/HtmlVaporSupportExample/Installation.swift
@@ -1,0 +1,29 @@
+import Html
+let installation: Node = [
+  .h2("Take it for a spin"),
+  .p("""
+We've included a sample Vapor application in this repo to show off its usage. To run the app
+immediately, simply do:
+"""
+  ),
+  .ul(
+    .li(.code("swift run HtmlVaporSupportExample")),
+    .li("Open your browser to \(.code("http://localhost:8080"))")
+  ),
+  .p("""
+The HTML for that page is constructed and rendered with swift-html!
+"""
+  ),
+  .p("""
+If you want to run the app in Xcode so that you can play around with the HTML, try this:
+"""
+  ),
+  .ul(
+    .li(.code("git clone https://github.com/pointfreeco/swift-html-vapor")),
+    .li(.code("cd swift-html-vapor")),
+    .li(.code("make xcodeproj")),
+    .li("Select the \(.code("HtmlVaporSupportExample")) target"),
+    .li("Build and run \(.code("cmd+R"))"),
+    .li("Open your browser to \(.code("http://localhost:8080"))")
+  )
+]

--- a/Sources/HtmlVaporSupportExample/Layout.swift
+++ b/Sources/HtmlVaporSupportExample/Layout.swift
@@ -1,0 +1,58 @@
+import Html
+
+// Functions that take nodes as input and return a new node can serve the purpose that "layouts" do in
+// most templating languages. You can have this function take additional arguments in order to customize
+// the layout, such as title and meta tags.
+func layout(title: String, content: Node) -> Node {
+  return [
+    .doctype,
+    .html(
+      .head(
+        .title(title),
+
+        // You can include inline stylesheets
+        .style(safe: stylesheet),
+
+        // Or link to external stylesheets
+        .link(attributes: [
+          .rel(.stylesheet),
+          .href("https://stackpath.bootstrapcdn.com/bootswatch/4.3.1/cerulean/bootstrap.min.css")
+          ])
+      ),
+      .body(
+        header,
+        .main(content),
+        footer,
+        // Load external scripts at the bottom of the document.
+        .script(attributes: [
+          .async(true),
+          .src("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js")
+          ])
+      )
+    )
+  ]
+}
+
+// A node that represents the header to use on each page.
+let header: Node = [
+  .header(
+    .h1("swift-html-vapor"),
+    .blockquote(
+      "A Vapor plugin for type-safe, transformable HTML views using ",
+      .a(attributes: [.href("https://github.com/pointfreeco/swift-html")], "swift-html")
+    ),
+    .ul(attributes: [], [
+      .li(.a(attributes: [.href("/")], "Home")),
+      .li(.a(attributes: [.href("/usage")], "Usage")),
+      .li(.a(attributes: [.href("/advanced-usage")], "Advanced Usage")),
+      .li(.a(attributes: [.href("/installation")], "Installation"))
+      ]
+    )
+  )
+]
+
+// A node that represents the footer to use on each page.
+let footer: Node = [
+  .hr,
+  .footer("© 2019 Point-Free, Inc.")
+]

--- a/Sources/HtmlVaporSupportExample/Stylesheet.swift
+++ b/Sources/HtmlVaporSupportExample/Stylesheet.swift
@@ -1,0 +1,35 @@
+let stylesheet: StaticString = """
+body {
+  padding: 0.5rem;
+  line-height: 1.35;
+  font-family: SanFranciscoDisplay-Regular;
+}
+
+blockquote {
+  border-left: 2px #777 solid;
+  font-style: italic;
+  color: #777;
+  margin-left: 1rem;
+  padding-left: 0.5rem;
+}
+
+pre {
+  background-color: #f3f3f3;
+  padding: 0.5rem;
+  overflow-x: scroll;
+}
+
+code {
+  background-color: #f3f3f3;
+  padding: 0.25rem;
+}
+
+li:not(:last-child) {
+    margin-bottom: 0.25rem;
+}
+
+h2 {
+  margin-top: 2rem;
+  margin-bottom: 0;
+}
+"""

--- a/Sources/HtmlVaporSupportExample/Usage.swift
+++ b/Sources/HtmlVaporSupportExample/Usage.swift
@@ -1,0 +1,23 @@
+import Html
+
+let usage: Node = [
+  .h2("Usage"),
+  .p("""
+To use the plugin all you have to do is return a `Node` value from your router callback:
+"""
+  ),
+  .pre(#"""
+import HtmlVaporSupport
+import Vapor
+
+let app = try Application()
+let router = try app.make(Router.self)
+
+router.get("/") { _ in
+  Node.h1("Hello, type-safe HTML on Vapor!")
+}
+
+try app.run()
+"""#
+  ),
+]

--- a/Sources/HtmlVaporSupportExample/main.swift
+++ b/Sources/HtmlVaporSupportExample/main.swift
@@ -4,110 +4,20 @@ import Vapor
 let app = try Application()
 let router = try app.make(Router.self)
 
-let stylesheet: StaticString = """
-body {
-  padding: 0.5rem;
-  line-height: 1.35;
-  font-family: SanFranciscoDisplay-Regular;
-}
-
-blockquote {
-  border-left: 2px #777 solid;
-  font-style: italic;
-  color: #777;
-  margin-left: 1rem;
-  padding-left: 0.5rem;
-}
-
-pre {
-  background-color: #f3f3f3;
-  padding: 0.5rem;
-  overflow-x: scroll;
-}
-
-code {
-  background-color: #f3f3f3;
-  padding: 0.25rem;
-}
-
-li:not(:last-child) {
-    margin-bottom: 0.25rem;
-}
-
-h2 {
-  margin-top: 2rem;
-  margin-bottom: 0;
-}
-"""
-
 router.get("/") { _ in
-  Node.html(
-    .head(.style(safe: stylesheet)),
-
-    .body(
-      .h1("swift-html-vapor"),
-      .blockquote(
-        "A Vapor plugin for type-safe, transformable HTML views using ",
-        .a(attributes: [.href("https://github.com/pointfreeco/swift-html")], "swift-html")
-      ),
-
-      .h2("Motivation"),
-      .p("""
-The most popular choice for rendering HTML in a Vapor web app is to use the Leaf templating language,
-but it exposes your application to runtime errors and invalid HTML. Our plugin prevents these
-runtime issues at compile-time by embedding HTML directly into Swift’s powerful type system. It uses the
-swift-html DSL for constructing HTML documents using plain Swift data structures.
-"""
-      ),
-
-      .h2("Usage"),
-      .p("""
-To use the plugin all you have to do is return a `Node` value from your router callback:
-"""
-      ),
-      .pre(#"""
-import HtmlVaporSupport
-import Vapor
-
-let app = try Application()
-let router = try app.make(Router.self)
-
-router.get("/") { _ in
-  Node.h1("Hello, type-safe HTML on Vapor!")
+  layout(title: "Home", content: home)
 }
 
-try app.run()
-"""#
-      ),
+router.get("/usage") { _ in
+  layout(title: "Usage", content: usage)
+}
 
-      .h2("Take it for a spin"),
-      .p("""
-We've included a sample Vapor application in this repo to show off its usage. To run the app
-immediately, simply do:
-"""
-      ),
-      .ul(
-        .li(.code("swift run HtmlVaporSupportExample")),
-        .li("Open your browser to \(.code("http://localhost:8080"))")
-      ),
-      .p("""
-The HTML for that page is constructed and rendered with swift-html!
-"""
-      ),
-      .p("""
-If you want to run the app in Xcode so that you can play around with the HTML, try this:
-"""
-      ),
-      .ul(
-        .li(.code("git clone https://github.com/pointfreeco/swift-html-vapor")),
-        .li(.code("cd swift-html-vapor")),
-        .li(.code("make xcodeproj")),
-        .li("Select the \(.code("HtmlVaporSupportExample")) target"),
-        .li("Build and run \(.code("cmd+R"))"),
-        .li("Open your browser to \(.code("http://localhost:8080"))")
-      )
-    )
-  )
+router.get("/advanced-usage") { _ in
+  layout(title: "Advanced Usage", content: advancedUsage)
+}
+
+router.get("/installation") { _ in
+  layout(title: "Installation", content: installation)
 }
 
 try app.run()


### PR DESCRIPTION
Inspired by #2 and #5 I thought I would try to beef up our sample app a bit. This adds more routes to the vapor app, puts the page content in their own Swift file, and creates a layout function that is used to create the full HTML document from a fragment of page content.