### PR TITLE
Html.Node adopts AsyncResponseEncodable

### DIFF
--- a/Sources/HtmlVaporSupport/HtmlVaporSupport.swift
+++ b/Sources/HtmlVaporSupport/HtmlVaporSupport.swift
@@ -12,3 +12,11 @@ extension Html.Node: ResponseEncodable {
     ))
   }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+extension Html.Node: AsyncResponseEncodable {
+	public func encodeResponse(for request: Request) async throws -> Response {
+		try await encodeResponse(for: request).get()
+	}
+}
+#endif


### PR DESCRIPTION
The addition allows for this to compile:

```
func routes(_ app: Application) throws {
	app.get { req async in
		layout(title: "Home", content: home)
	}
}
```
