### PR TITLE
Add `.editorconfig` for consistent code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Xcode 16 added support for the [EditorConfig standard](https://editorconfig.org/)[^1]. This allows a project/repo to specify basic formatting rules so the editor can behave correctly.[^2]

> [!NOTE]
> You may need to quit and relaunch Xcode for it to pick up the `.editorconfig` file after switching to a branch where it's present.[^3]

The added `.editorconfig` file contains:

```
# editorconfig.org
root = true

[*]
indent_style = space
indent_size = 2
trim_trailing_whitespace = true
insert_final_newline = true
```

- `root = true`: Specifies that this is the top-most .editorconfig file. The file search will stop here.
- `indent_style = space`: Uses soft tabs (spaces) for indentation instead of hard tabs.
- `indent_size = 2`: Sets the indentation to 2 columns.
- `trim_trailing_whitespace = true`: Removes any whitespace characters preceding newline characters.
- `insert_final_newline = true`: Ensures the file ends with a newline when saving.

These settings apply to all files in the project (`[*]`).

**This change make much easier the process of switch between projects that use 2-space and 4-space indentation (what is quite common in your community).**

[^1]: [Xcode 16 Beta 2 Release Notes–Source Editor New Features](https://arc.net/l/quote/zuzqnfeq)
[^2]: Inspired by: [Add an EditorConfig file](https://github.com/swiftlang/swift-syntax/pull/2714)
[^3]: [Xcode 16 Beta 2 Release Notes–Source Editor Known Issues](https://arc.net/l/quote/olmnhsqo)